### PR TITLE
Implement Custom Header Inline Logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Specifically, this packages builds upon the [Theme Toolkit](https://github.com/g
 - Filters Genesis theme settings defaults, or forces them to specific values.
 - Register and unregister widget areas, added by Genesis (extends Theme Toolkit functionality)
 - Customise the footer credits string.
+- Implement a custom inline logo using WordPress `add_theme_support( 'custom-logo' )` functionality.
 
 ## Why?
 
@@ -50,6 +51,7 @@ namespace Gamajo\ExampleTheme;
 
 use BrightNucleus\Config\ConfigFactory;
 use Gamajo\GenesisThemeToolkit\BreadcrumbArgs;
+use Gamajo\GenesisThemeToolkit\CustomLogo;
 use Gamajo\GenesisThemeToolkit\FooterCreds;
 use Gamajo\GenesisThemeToolkit\Layouts;
 use Gamajo\GenesisThemeToolkit\Templates;
@@ -80,6 +82,7 @@ function setup() {
 		Layouts::class,
 		ThemeSettings::class,
 		WidgetAreas::class,
+		CustomLogo::class,
 	];
 
 	// Apply logic in bricks, with configuration defined in config/defaults.php.

--- a/docs/example-config.php
+++ b/docs/example-config.php
@@ -13,6 +13,7 @@ declare( strict_types = 1 );
 namespace Gamajo\ExampleTheme;
 
 use Gamajo\GenesisThemeToolkit\BreadcrumbArgs;
+use Gamajo\GenesisThemeToolkit\CustomLogo;
 use Gamajo\GenesisThemeToolkit\Layouts;
 use Gamajo\GenesisThemeToolkit\Templates;
 use Gamajo\GenesisThemeToolkit\ThemeSettings;
@@ -121,6 +122,12 @@ $gamajo_genesis_widget_areas = [
 	],
 ];
 
+$gamajo_genesis_custom_logo = [
+    CustomLogo::WIDTH            => 600,
+    CustomLogo::HEIGHT           => 160,
+    CustomLogo::SITE_DESCRIPTION => false,
+];
+
 return [
 	'Gamajo' => [
 		'ExampleTheme' => [
@@ -133,6 +140,7 @@ return [
 			GenesisThemeToolkit::LAYOUTS        => $gamajo_genesis_layouts,
 			GenesisThemeToolkit::THEMESETTINGS  => $gamajo_genesis_theme_settings,
 			GenesisThemeToolkit::WIDGETAREAS    => $gamajo_genesis_widget_areas,
+			GenesisThemeToolkit::CUSTOMLOGO     => $gamajo_genesis_custom_logo,
 		],
 	],
 ];

--- a/src/CustomLogo.php
+++ b/src/CustomLogo.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * This file contains elements for using WordPress Custom Logo functionality with Genesis.
+ *
+ * @package   Gamajo\GenesisThemeTookit
+ * @author    Gary Jones
+ * @copyright Gamajo
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
+namespace Gamajo\GenesisThemeToolkit;
+
+use Gamajo\ThemeToolkit\Brick;
+
+/**
+ * Adds support for a custom logo set using the customizer with WP's built in add_theme_support( 'custom-logo' );
+ *
+ * Flex height and flex width parameters are set true by default, but they can be overwritten in config.
+ *
+ * Setting SITE_DESCRIPTION to false will hide `.site-description` using `.screen-reader-text`.
+ *
+ * Example config:
+ *
+ * ```
+ * $generico_custom_logo = [
+ *     CustomLogo::HEIGHT           => 600,
+ *     CustomLogo::WIDTH            => 160,
+ *     CustomLogo::FLEX_HEIGHT      => false,
+ *     CustomLogo::SITE_DESCRIPTION => false,
+ * ];
+ * ```
+ *
+ * And then:
+ *
+ * ```
+ * return [
+ *     'Gamajo' => [
+ *         'Theme' => [
+ *             Gamajo::CUSTOMLOGO => $gamajo_custom_logo,
+ *         ],
+ *     ],
+ * ];
+ * ```
+ *
+ * @package Gamajo\GenesisThemeToolkit
+ */
+class CustomLogo extends Brick
+{
+    const HEIGHT = 'height';
+    const WIDTH = 'width';
+    const FLEX_HEIGHT = 'flex_height';
+    const FLEX_WIDTH = 'flex_width';
+    const SITE_DESCRIPTION = 'show_site_description';
+
+    /**
+     * Apply filters and hooks.
+     */
+    public function apply()
+    {
+        if (!($this->config->hasKey(self::HEIGHT) && $this->config->hasKey(self::WIDTH))) {
+            return;
+        }
+
+        add_theme_support('custom-logo', [
+            'height'      => $this->config->getKey(self::HEIGHT),
+            'width'       => $this->config->getKey(self::WIDTH),
+            'flex-height' => $this->config->hasKey(self::FLEX_HEIGHT) ? $this->config->getKey(self::FLEX_HEIGHT) : true,
+            'flex-width'  => $this->config->hasKey(self::FLEX_WIDTH) ? $this->config->getKey(self::FLEX_WIDTH) : true,
+        ]);
+
+        add_filter('genesis_seo_title', [$this, 'inlineLogoMarkup'], 10, 3);
+
+        if (false === $this->config->getKey(self::SITE_DESCRIPTION)) {
+            add_filter('genesis_attr_site-description', [$this, 'hideSiteDescription']);
+        }
+    }
+
+    /**
+     * Add an image inline in the site title element for the logo.
+     *
+     * @author @_AlphaBlossom
+     * @author @_neilgee
+     * @author @_JiveDig
+     * @author @_srikat
+     *
+     * @param string $title Current markup of title.
+     * @param string $inside Markup inside the title.
+     * @param string $wrap Wrapping element for the title.
+     *
+     * @return string Updated site title markup.
+     */
+    public function inlineLogoMarkup($title, $inside, $wrap): string
+    {
+        if (!$this->hasCustomLogo()) {
+            return $title;
+        }
+
+        $inside = sprintf(
+            '<span class="screen-reader-text">%s</span>%s',
+            esc_html(get_bloginfo('name')),
+            get_custom_logo()
+        );
+
+        // Build the title.
+        $title = genesis_markup(array(
+            'open'    => sprintf("<{$wrap} %s>", genesis_attr('site-title')),
+            'close'   => "</{$wrap}>",
+            'content' => $inside,
+            'context' => 'site-title',
+            'echo'    => false,
+            'params'  => array(
+                'wrap' => $wrap,
+            ),
+        ));
+
+        return $title;
+    }
+
+    /**
+     * Add class for screen readers to site description.
+     *
+     * This will keep the site description markup but will not have any visual presence on the page
+     * This runs if there is a logo image set in the Customizer.
+     *
+     * @author @_neilgee
+     * @author @_srikat
+     *
+     * @param array $attributes Current attributes.
+     *
+     * @return array Array of attributes.
+     */
+    public function hideSiteDescription($attributes): array
+    {
+        if ($this->hasCustomLogo()) {
+            $attributes['class'] .= ' screen-reader-text';
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Check whether we're using a custom logo.
+     *
+     * @return bool
+     */
+    protected function hasCustomLogo(): bool
+    {
+        return function_exists('has_custom_logo') && has_custom_logo();
+    }
+}

--- a/src/CustomLogo.php
+++ b/src/CustomLogo.php
@@ -24,7 +24,7 @@ use Gamajo\ThemeToolkit\Brick;
  * Example config:
  *
  * ```
- * $generico_custom_logo = [
+ * $gamajo_custom_logo = [
  *     CustomLogo::HEIGHT           => 600,
  *     CustomLogo::WIDTH            => 160,
  *     CustomLogo::FLEX_HEIGHT      => false,

--- a/src/GenesisThemeToolkit.php
+++ b/src/GenesisThemeToolkit.php
@@ -35,6 +35,7 @@ namespace Gamajo\GenesisThemeToolkit;
 class GenesisThemeToolkit
 {
     const BREADCRUMBARGS = 'BreadcrumbArgs';
+    const CUSTOMLOGO = 'CustomLogo';
     const FOOTERCREDS = 'FooterCreds';
     const LAYOUTS = 'Layouts';
     const TEMPLATES = 'Templates';


### PR DESCRIPTION
Uses WordPress `add_theme_support('custom-logo')` to implement a custom header inline logo for Genesis themes. Adds optional support for visually hiding the site description with `.screen-reader-text` by passing an additional config parameter.

See #10